### PR TITLE
feature: add rowMode option to support array and object row formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to node-netezza will be documented in this file.
 
+## [1.1.0] - 2025-11-13
+
+### Added
+- **Row mode option** (`rowMode`) for controlling row return format
+  - `'object'` mode (default): Returns rows as objects with column names as keys
+  - `'array'` mode: Returns rows as arrays with values in column order
+- Array mode solves the duplicate column name issue (e.g., `SELECT 1 as a, 2 as a`)
+- New example `array-rows.js` demonstrating both row modes and duplicate column handling
+
+### Changed
+- `QueryResult.rows` type updated to support both `QueryRow[]` and `any[][]`
+
+### Improved
+- Documentation updated with array mode usage examples
+- All examples validated and connection details updated
+
 ## [1.0.0] - 2025-01-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ async function example() {
     );
 
     for (const row of results.rows) {
-      console.log(row);
+      console.log(row);  // { id: 1, name: 'John Doe', email: 'john@example.com' }
     }
   } finally {
     await conn.close();
@@ -61,6 +61,29 @@ async function example() {
 }
 
 example().catch(console.error);
+```
+
+### Array Row Mode
+
+For handling duplicate column names or improved performance, use `rowMode: 'array'`:
+
+```javascript
+const conn = await connect({
+  user: 'admin',
+  password: 'password',
+  database: 'db1',
+  rowMode: 'array'  // Return rows as arrays
+});
+
+const results = await conn.execute('SELECT id, name, email FROM customers');
+for (const row of results.rows) {
+  console.log(row);  // [1, 'John Doe', 'john@example.com']
+  console.log('ID:', row[0], 'Name:', row[1], 'Email:', row[2]);
+}
+
+// Handles duplicate column names
+const dupes = await conn.execute('SELECT 1 as value, 2 as value');
+console.log(dupes.rows[0]);  // [1, 2] - all values preserved!
 ```
 
 ## Debugging
@@ -108,6 +131,10 @@ Creates a new connection to Netezza.
   - 3: Only secured session
 - `timeout` (number, optional): Connection timeout in milliseconds
 - `debug` (boolean, default: false): Enable debug logging to console
+- `rowMode` (string, default: 'object'): Row return format
+  - `'object'`: Returns rows as objects with column names as keys (e.g., `{ id: 1, name: 'John' }`)
+  - `'array'`: Returns rows as arrays with values in column order (e.g., `[1, 'John']`)
+  - Array mode is useful for handling duplicate column names and can be slightly more efficient
 - `ssl` (object, optional): SSL/TLS options
   - `ca` (string | Buffer, optional): CA certificate for server verification
   - `rejectUnauthorized` (boolean, default: true): Whether to reject unauthorized connections

--- a/examples/array-rows.js
+++ b/examples/array-rows.js
@@ -1,0 +1,148 @@
+const { connect } = require('../dist/index');
+
+async function example() {
+  // Create connection with rowMode set to 'array'
+  console.log('Connecting to Netezza with rowMode: array...');
+  
+  const conn = await connect({
+    user: 'admin',
+    password: 'password',
+    host: 'localhost',
+    port: 5480,
+    database: 'testdb',
+    securityLevel: 1,
+    rowMode: 'array'  // Return rows as arrays instead of objects
+  });
+
+  try {
+    console.log('Connected successfully!');
+    
+    // Create a test table
+    console.log('\nCreating table...');
+    await conn.execute(
+      `CREATE TABLE IF NOT EXISTS test_array_rows (
+        id INTEGER,
+        name VARCHAR(50),
+        score NUMERIC(10,2)
+      )`
+    );
+    console.log('Table created');
+
+    // Insert test data
+    console.log('\nInserting data...');
+    await conn.execute(
+      'INSERT INTO test_array_rows VALUES (?, ?, ?)',
+      [1, 'Alice', 95.5]
+    );
+    await conn.execute(
+      'INSERT INTO test_array_rows VALUES (?, ?, ?)',
+      [2, 'Bob', 87.3]
+    );
+    await conn.execute(
+      'INSERT INTO test_array_rows VALUES (?, ?, ?)',
+      [3, 'Charlie', 92.1]
+    );
+    console.log('Data inserted');
+
+    // Query with array rows
+    console.log('\nQuerying with rowMode: array...');
+    const results = await conn.execute('SELECT * FROM test_array_rows ORDER BY id');
+    console.log('Found', results.rowCount, 'rows:');
+    console.log('Field names:', results.fields.map(f => f.name).join(', '));
+    console.log('\nRows as arrays:');
+    for (const row of results.rows) {
+      console.log('  ', row);  // Arrays: [1, 'Alice', 95.5]
+    }
+
+    // Demonstrate duplicate column name handling
+    console.log('\n\nDemonstrating duplicate column names...');
+    console.log('Query: SELECT 1 as value, 2 as value, 3 as value');
+    const duplicateResults = await conn.execute('SELECT 1 as value, 2 as value, 3 as value');
+    console.log('Result (array mode handles duplicates):');
+    console.log('  ', duplicateResults.rows[0]);  // [1, 2, 3]
+    
+    // Show another example with calculated columns
+    console.log('\n\nQuery with calculated columns:');
+    const calcResults = await conn.execute(
+      `SELECT 
+        id,
+        score,
+        score * 1.1 as score,
+        score * 0.9 as score
+      FROM test_array_rows 
+      WHERE id = ?`,
+      [1]
+    );
+    console.log('Field names:', calcResults.fields.map(f => f.name).join(', '));
+    console.log('Result:', calcResults.rows[0]);
+    console.log('  - All values accessible by position, even with duplicate column names!');
+
+    // Accessing by index
+    console.log('\n\nAccessing values by index:');
+    const row = results.rows[0];
+    console.log('Row:', row);
+    console.log('ID (index 0):', row[0]);
+    console.log('Name (index 1):', row[1]);
+    console.log('Score (index 2):', row[2]);
+
+    // Drop table
+    console.log('\nDropping table...');
+    await conn.execute('DROP TABLE test_array_rows');
+    console.log('Table dropped');
+
+  } catch (error) {
+    console.error('Error:', error);
+  } finally {
+    // Close connection
+    console.log('\nClosing connection...');
+    await conn.close();
+    console.log('Connection closed');
+  }
+}
+
+// Compare with object mode
+async function compareWithObjectMode() {
+  console.log('\n\n========================================');
+  console.log('COMPARISON: Object mode (default)');
+  console.log('========================================\n');
+
+  const conn = await connect({
+    user: 'admin',
+    password: 'password',
+    host: 'localhost',
+    port: 5480,
+    database: 'testdb',
+    securityLevel: 1
+    // rowMode defaults to 'object'
+  });
+
+  try {
+    // Create and populate table
+    await conn.execute(
+      `CREATE TABLE IF NOT EXISTS test_object_rows (
+        id INTEGER,
+        name VARCHAR(50)
+      )`
+    );
+    await conn.execute('INSERT INTO test_object_rows VALUES (?, ?)', [1, 'Alice']);
+
+    // Query with duplicate column names
+    console.log('Query: SELECT 1 as value, 2 as value');
+    const result = await conn.execute('SELECT 1 as value, 2 as value');
+    console.log('Result (object mode - last value wins):');
+    console.log('  ', result.rows[0]);  // { value: 2 } - first value is lost!
+
+    // Cleanup
+    await conn.execute('DROP TABLE test_object_rows');
+    await conn.close();
+
+  } catch (error) {
+    console.error('Error:', error);
+    try { await conn.close(); } catch {}
+  }
+}
+
+// Run both examples
+example()
+  .then(() => compareWithObjectMode())
+  .catch(console.error);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-netezza",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Pure Node.js driver for IBM Netezza",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- Add rowMode option ('object' | 'array') to ConnectionOptions
- Update QueryResult to support both
- Modify parseDataRow to return arrays when rowMode is 'array'
- Solve duplicate column name issue with array mode
- Add comprehensive array-rows.js example
- Update README with array mode documentation
- Update CHANGELOG for v1.1.0 release